### PR TITLE
take into account h.Unsynchronisation and add some sanity check

### DIFF
--- a/id3v2.go
+++ b/id3v2.go
@@ -252,7 +252,7 @@ func (r *Unsynchroniser) Read(p []byte) (int, error) {
 		}
 		if r.prevWasFF && p[i] == 0 {
 			p[i] = p[i+1]
-			r.prevWasFF = false
+			r.prevWasFF = (p[i+1] == 255)
 			continue
 		}
 		if p[i] == 255 && p[i+1] == 0 {


### PR DESCRIPTION
I have some MP3 which have tag with Unsynchronisation.
This patch deals with it.
When testing on my mp3 collection, I found several instance where the lib tried to decode 0 sized frames or frames larger than the whole id3 tag. I've added a security for theses cases