### PR TITLE
Adding slightly tested support for OGG, using VorbisComment parsing from flac.go

### DIFF
--- a/ogg.go
+++ b/ogg.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	idType      byte = 1
-	commentType      = 3
+	idType      int = 1
+	commentType     = 3
 )
 
 // ReadOGGTags reads OGG metadata from the io.ReadSeeker, returning the resulting
@@ -94,7 +94,7 @@ func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
 	}
 
 	// Packet type is comment, type 3
-	t, err := readInt(r, 1)
+	t, err = readInt(r, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/ogg.go
+++ b/ogg.go
@@ -1,0 +1,101 @@
+// Copyright 2015, David Howden
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tag
+
+import (
+	"errors"
+	"io"
+	"os"
+)
+
+// ReadOGGTags reads OGG metadata from the io.ReadSeeker, returning the resulting
+// metadata in a Metadata implementation, or non-nil error if there was a problem.
+// TODO: Needs a more generic return type than "metadataFLAC" and the "FLAC" format is not as obvious as "Vorbis comment"
+func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
+	_, err := r.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return nil, err
+	}
+
+	oggs, err := readString(r, 4)
+	if err != nil {
+		return nil, err
+	}
+	if oggs != "OggS" {
+		return nil, errors.New("expected 'OggS'")
+	}
+
+	_, err = r.Seek(22, os.SEEK_CUR)
+	if err != nil {
+		return nil, err
+	}
+
+	nS, err := readInt(r, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = r.Seek(int64(nS), os.SEEK_CUR)
+	if err != nil {
+		return nil, err
+	}
+
+	idComment, err := readInt(r, 1)
+	if err != nil {
+		return nil, err
+	}
+	if idComment != 1 {
+		return nil, errors.New("expected 'vorbis' identification type 1")
+	}
+
+	_, err = r.Seek(29, os.SEEK_CUR)
+	if err != nil {
+		return nil, err
+	}
+
+	oggs, err = readString(r, 4)
+	if err != nil {
+		return nil, err
+	}
+	if oggs != "OggS" {
+		return nil, errors.New("expected 'OggS'")
+	}
+
+	_, err = r.Seek(22, os.SEEK_CUR)
+	if err != nil {
+		return nil, err
+	}
+
+	nS, err = readInt(r, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = r.Seek(int64(nS), os.SEEK_CUR)
+	if err != nil {
+		return nil, err
+	}
+
+	typeComment, err := readInt(r, 1)
+	if err != nil {
+		return nil, err
+	}
+	if typeComment != 3 {
+		return nil, errors.New("expected 'vorbis' comment type 3")
+	}
+
+	_, err = r.Seek(6, os.SEEK_CUR)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &metadataFLAC{
+		c: make(map[string]string),
+	}
+
+	err = m.readVorbisComment(r)
+
+	return m, err
+}

--- a/ogg.go
+++ b/ogg.go
@@ -10,8 +10,14 @@ import (
 	"os"
 )
 
+const (
+	idType      byte = 1
+	commentType      = 3
+)
+
 // ReadOGGTags reads OGG metadata from the io.ReadSeeker, returning the resulting
 // metadata in a Metadata implementation, or non-nil error if there was a problem.
+// See http://www.xiph.org/vorbis/doc/Vorbis_I_spec.html and http://www.xiph.org/ogg/doc/framing.html for details
 // TODO: Needs a more generic return type than "metadataFLAC" and the "FLAC" format is not as obvious as "Vorbis comment"
 func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
 	_, err := r.Seek(0, os.SEEK_SET)
@@ -27,6 +33,8 @@ func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
 		return nil, errors.New("expected 'OggS'")
 	}
 
+	// Skip 22 bytes of Page header to read page_segments length byte at position 26
+	// See http://www.xiph.org/ogg/doc/framing.html
 	_, err = r.Seek(22, os.SEEK_CUR)
 	if err != nil {
 		return nil, err
@@ -37,24 +45,30 @@ func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
 		return nil, err
 	}
 
+	// Seek and discard the segments
 	_, err = r.Seek(int64(nS), os.SEEK_CUR)
 	if err != nil {
 		return nil, err
 	}
 
-	idComment, err := readInt(r, 1)
+	// First packet type is identification, type 1
+	t, err := readInt(r, 1)
 	if err != nil {
 		return nil, err
 	}
-	if idComment != 1 {
+	if t != idType {
 		return nil, errors.New("expected 'vorbis' identification type 1")
 	}
 
+	// Seek and discard 29 bytes from common and identification header
+	// See http://www.xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-610004.2
 	_, err = r.Seek(29, os.SEEK_CUR)
 	if err != nil {
 		return nil, err
 	}
 
+	// Beginning of a new page. Comment packet is on a separate page
+	// See http://www.xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-132000A.2
 	oggs, err = readString(r, 4)
 	if err != nil {
 		return nil, err
@@ -63,6 +77,7 @@ func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
 		return nil, errors.New("expected 'OggS'")
 	}
 
+	// Skip page 2 header, same as line 30
 	_, err = r.Seek(22, os.SEEK_CUR)
 	if err != nil {
 		return nil, err
@@ -78,14 +93,16 @@ func ReadOGGTags(r io.ReadSeeker) (Metadata, error) {
 		return nil, err
 	}
 
-	typeComment, err := readInt(r, 1)
+	// Packet type is comment, type 3
+	t, err := readInt(r, 1)
 	if err != nil {
 		return nil, err
 	}
-	if typeComment != 3 {
+	if t != commentType {
 		return nil, errors.New("expected 'vorbis' comment type 3")
 	}
 
+	// Seek and discard 6 bytes from common header
 	_, err = r.Seek(6, os.SEEK_CUR)
 	if err != nil {
 		return nil, err

--- a/tag.go
+++ b/tag.go
@@ -29,6 +29,9 @@ func ReadFrom(r io.ReadSeeker) (Metadata, error) {
 	case string(b[0:4]) == "fLaC":
 		return ReadFLACTags(r)
 
+	case string(b[0:4]) == "OggS":
+		return ReadOGGTags(r)
+
 	case string(b[4:11]) == "ftypM4A":
 		return ReadAtoms(r)
 


### PR DESCRIPTION
As the commit message states, this is slightly tested, I just grabbed a few ogg albums from various sources to test against, it works.
It took me a few hours to write this code from reading the Ogg documentation and opening .ogg files in an hex editor so it might not be failproof.
I should add I'm relatively new to Go so please make any change you see fit to make the code look better, it's relatively verbose as is! :)

Since the metadata format is the same, it's using the `readVorbisComment()` function from the flac.go file.
As a result it returns `metadataFLAC` and returns `FLAC` as its format.
Maybe we could change the FLAC format name to `"Vorbis"` since they are fundamentaly the same in terms of metadata encoding.

