### PR TITLE
Support for more id3v2 frames and a bugfix

### DIFF
--- a/id3v2.go
+++ b/id3v2.go
@@ -211,15 +211,36 @@ func readID3v2Frames(r io.Reader, h *ID3v2Header) (map[string]interface{}, error
 		}
 
 		switch {
+		case name == "TXXX" || name == "TXX":
+			t, err := readTextWithDescrFrame(b, false, true) // no lang, but enc
+			if err != nil {
+				return nil, err
+			}
+			result[rawName] = t
+
 		case name[0] == 'T':
-			txt, err := readTFrame(b)
+			txt, err := readTFrame(b, true) // text is encoded
+			if err != nil {
+				return nil, err
+			}
+			result[rawName] = txt
+
+		case name == "WXXX" || name == "WXX":
+			t, err := readTextWithDescrFrame(b, false, false) // no lang, no enc
+			if err != nil {
+				return nil, err
+			}
+			result[rawName] = t
+
+		case name[0] == 'W':
+			txt, err := readTFrame(b, false) // url are not encoded
 			if err != nil {
 				return nil, err
 			}
 			result[rawName] = txt
 
 		case name == "COMM" || name == "USLT":
-			t, err := readTextWithDescrFrame(b)
+			t, err := readTextWithDescrFrame(b, true, true) // both lang and enc
 			if err != nil {
 				return nil, err
 			}

--- a/id3v2.go
+++ b/id3v2.go
@@ -225,6 +225,13 @@ func readID3v2Frames(r io.Reader, h *ID3v2Header) (map[string]interface{}, error
 			}
 			result[rawName] = txt
 
+		case name == "UFID" || name == "UFI":
+			t, err := readUfid(b)
+			if err != nil {
+				return nil, err
+			}
+			result[rawName] = t
+
 		case name == "WXXX" || name == "WXX":
 			t, err := readTextWithDescrFrame(b, false, false) // no lang, no enc
 			if err != nil {

--- a/id3v2frames.go
+++ b/id3v2frames.go
@@ -195,6 +195,26 @@ func readTextWithDescrFrame(b []byte, hasLang bool, encoded bool) (*Comm, error)
 	}, nil
 }
 
+// UFID is composed of a provider (frequently an URL and a binary identifier)
+// The identifier can be a text (Musicbrainz use texts, but not necessary)
+type Ufid struct {
+	Provider   string
+	Identifier []byte
+}
+
+func (u Ufid) String() string {
+	return fmt.Sprintf("%v (%v)", u.Provider, string(u.Identifier))
+}
+
+func readUfid(b []byte) (*Ufid, error) {
+	result := bytes.SplitN(b, []byte{0}, 2)
+
+	return &Ufid{
+		Provider:   string(result[0]),
+		Identifier: result[1],
+	}, nil
+}
+
 var pictureTypes = map[byte]string{
 	0x00: "Other",
 	0x01: "32x32 pixels 'file icon' (PNG only)",


### PR DESCRIPTION
The first patch correct a bug when analyzing data separated with one or two 00 when the first part ends with a 0 (I found the bug while decoding TXXX frames by the way)

The other two add support for TXXX (and WXXX) and UFID frames
This frames are used by Musicbrainz Piccard and can be used to retreve information on the MusticBrainz database or on LastFM and other site using MusicBrainz identifiers
W frames are a variant of T frames, without encoding and thus easy to support by tweaking the code a bit.