### PR TITLE
Fix a bug in Sum() and add all id3frames in Raw()

### DIFF
--- a/id3v2.go
+++ b/id3v2.go
@@ -266,6 +266,8 @@ func readID3v2Frames(r io.Reader, h *ID3v2Header) (map[string]interface{}, error
 				return nil, err
 			}
 			result[rawName] = p
+		default:
+			result[rawName] = b
 		}
 
 		continue

--- a/sum.go
+++ b/sum.go
@@ -141,7 +141,7 @@ func SumID3v2(r io.ReadSeeker) (string, error) {
 		return "", fmt.Errorf("error reading ID3v2 header: %v", err)
 	}
 
-	_, err = r.Seek(int64(h.Size), os.SEEK_SET)
+	_, err = r.Seek(int64(h.Size)+10, os.SEEK_SET)
 	if err != nil {
 		return "", fmt.Errorf("error seeking to end of ID3V2 header: %v", err)
 	}


### PR DESCRIPTION
The Seek in SumID3v2() didn't take into account the size of the ID3v2 Header
(10 bytes). Thus when tagging the same file with or without it's tag, there was
a discrepancy. (

And I've added a default case when parsing the id3v2 tags, by storing the
binary content to Raw()