### PR TITLE
Support for numeric genres in id3v2

### DIFF
--- a/id3v2_test.go
+++ b/id3v2_test.go
@@ -129,3 +129,24 @@ func TestUnsynchroniserSplitReads(t *testing.T) {
 		}
 	}
 }
+
+func TestGenreExpension(t *testing.T) {
+	var tests = map[string]string{
+		"Test":         "Test",
+		"((17)":        "(17)",
+		"(17) Test":    "Rock Test",
+		"(17)Test":     "Rock Test",
+		"(17)":         "Rock",
+		"Test(17)":     "Test Rock",
+		"Test (17)":    "Test Rock",
+		"(17)(93)":     "Rock Psychedelic Rock",
+		"(17)Test(93)": "Rock Test Psychedelic Rock",
+	}
+	for g, r := range tests {
+		got := id3v2genre(g)
+
+		if got != r {
+			t.Errorf("[%v] got: %v, expected %v", g, got, r)
+		}
+	}
+}

--- a/id3v2metadata.go
+++ b/id3v2metadata.go
@@ -87,7 +87,7 @@ func (m metadataID3v2) Composer() string {
 }
 
 func (m metadataID3v2) Genre() string {
-	return m.getString(frames.Name("genre", m.Format()))
+	return id3v2genre(m.getString(frames.Name("genre", m.Format())))
 }
 
 func (m metadataID3v2) Year() int {


### PR DESCRIPTION
TCON

The 'Content type', which previously was stored as a one byte numeric value
only, is now a numeric string. You may use one or several of the types as
ID3v1.1 did or, since the category list would be impossible to maintain with
accurate and up to date categories, define your own.

References to the ID3v1 genres can be made by, as first byte, enter "("
followed by a number from the genres list (appendix A) and ended with a ")"
character. This is optionally followed by a refinement, e.g. "(21)" or
"(4)Eurodisco". Several references can be made in the same frame, e.g.
"(51)(39)". If the refinement should begin with a "(" character it should be
replaced with "((", e.g. "((I can figure out any genre)" or "(55)((I
think...)". The following new content types is defined in ID3v2 and is
implemented in the same way as the numerig content types, e.g. "(RX)".

I made a partial implentation as, in practice, I've only seen TCON with
one numeric value.

To test it, use the id3v2 tool

% id3v2 -g 79 test.mp3
% id3v2 -l test.mp3| grep TCON
TCON (Content type): Hard Rock (79)
% ./tag test.mp3| grep Genre
 Genre: (79)

With the patch :
% go build && ./tag test.mp3| grep Genre
 Genre: Hard Rock