### PR TITLE
fix bug with invalid APIC mimetype

### DIFF
--- a/id3v2frames.go
+++ b/id3v2frames.go
@@ -597,6 +597,9 @@ func readAPICFrame(b []byte) (*Picture, error) {
 	mimeType := string(mimeDataSplit[0])
 
 	b = mimeDataSplit[1]
+	if len(b) < 1 {
+		return nil, fmt.Errorf("error decoding APIC mimetype")
+	}
 	picType := b[0]
 
 	descDataSplit, err := dataSplit(b[1:], enc)


### PR DESCRIPTION
Return an error if the mimetype can't be decoded rather than
panicking. See #28.