### PR TITLE
Add parsing year for vorbis comment

### DIFF
--- a/vorbis.go
+++ b/vorbis.go
@@ -211,6 +211,8 @@ func (m *metadataVorbis) Year() int {
 	// The date need to follow the international standard https://en.wikipedia.org/wiki/ISO_8601
 	// and obviously the VorbisComment standard https://wiki.xiph.org/VorbisComment#Date_and_time
 	switch len(m.c["date"]) {
+	case 0:
+		return 0
 	case 4:
 		dateFormat = "2006"
 	case 7:

--- a/vorbis.go
+++ b/vorbis.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func newMetadataVorbis() *metadataVorbis {
@@ -205,8 +206,23 @@ func (m *metadataVorbis) Genre() string {
 }
 
 func (m *metadataVorbis) Year() int {
-	// FIXME: try to parse the date in m.c["date"] to extract this
-	return 0
+	var dateFormat string
+
+	switch len(m.c["date"]) {
+	case 4:
+		dateFormat = "2006"
+	case 6:
+		dateFormat = "012006"
+	case 7:
+		dateFormat = "01-2006"
+	case 8:
+		dateFormat = "02012006"
+	case 10:
+		dateFormat = "02-01-2006"
+	}
+
+	t, _ := time.Parse(dateFormat, m.c["date"])
+	return t.Year()
 }
 
 func (m *metadataVorbis) Track() (int, int) {

--- a/vorbis.go
+++ b/vorbis.go
@@ -206,21 +206,19 @@ func (m *metadataVorbis) Genre() string {
 }
 
 func (m *metadataVorbis) Year() int {
-	// dateFormat is a string (layout) format using the standard layout motifs
+	// dateFormat is a string (format) build with the golang format pattern
 	// present in the time/format.go file https://golang.org/src/time/format.go#L88
 	var dateFormat string
 
+	// The date need to follow the international standard https://en.wikipedia.org/wiki/ISO_8601
+	// and obviously the VorbisComment standard https://wiki.xiph.org/VorbisComment#Date_and_time
 	switch len(m.c["date"]) {
 	case 4:
 		dateFormat = "2006"
-	case 6:
-		dateFormat = "012006"
 	case 7:
-		dateFormat = "01-2006"
-	case 8:
-		dateFormat = "02012006"
+		dateFormat = "2006-01"
 	case 10:
-		dateFormat = "02-01-2006"
+		dateFormat = "2006-01-02"
 	}
 
 	t, _ := time.Parse(dateFormat, m.c["date"])

--- a/vorbis.go
+++ b/vorbis.go
@@ -206,6 +206,8 @@ func (m *metadataVorbis) Genre() string {
 }
 
 func (m *metadataVorbis) Year() int {
+	// dateFormat is a string (layout) format using the standard layout motifs
+	// present in the time/format.go file https://golang.org/src/time/format.go#L88
 	var dateFormat string
 
 	switch len(m.c["date"]) {

--- a/vorbis.go
+++ b/vorbis.go
@@ -206,8 +206,6 @@ func (m *metadataVorbis) Genre() string {
 }
 
 func (m *metadataVorbis) Year() int {
-	// dateFormat is a string (format) build with the golang format pattern
-	// present in the time/format.go file https://golang.org/src/time/format.go#L88
 	var dateFormat string
 
 	// The date need to follow the international standard https://en.wikipedia.org/wiki/ISO_8601


### PR DESCRIPTION
This parse the date and exctract the year for vorbis comment tags.

Don't know if this was the idea you had in mind. I need this to work so I proposed this small PR.