### PR TITLE
Check versions before using data length indicator

### DIFF
--- a/id3v2.go
+++ b/id3v2.go
@@ -267,9 +267,10 @@ func readID3v2Frames(r io.Reader, offset uint, h *id3v2Header) (map[string]inter
 			break
 		}
 
+		var dataLengthIndicator uint
 		if flags != nil {
-			if flags.Compression {
-				_, err = read7BitChunkedUint(r, 4) // read 4
+			if flags.Compression || flags.DataLengthIndicator {
+				dataLengthIndicator, err = read7BitChunkedUint(r, 4) // read 4
 				if err != nil {
 					return nil, err
 				}
@@ -282,6 +283,10 @@ func readID3v2Frames(r io.Reader, offset uint, h *id3v2Header) (map[string]inter
 					return nil, err
 				}
 				size--
+			}
+
+			if flags.DataLengthIndicator {
+				size = dataLengthIndicator
 			}
 		}
 


### PR DESCRIPTION
Variation of #64 that checks that we are in ID3 v2.4 and errors if not.

Sorry - couldn't work out how to merge my changes into your pull request.