### PR TITLE
Add MP4 tag support for Serato and Mixed In Key

### DIFF
--- a/mp4.go
+++ b/mp4.go
@@ -45,6 +45,12 @@ var atoms = atomNames(map[string]string{
 	"disk":    "disc",
 })
 
+var means = map[string]bool{
+	"com.apple.iTunes":          true,
+	"com.mixedinkey.mixedinkey": true,
+	"com.serato.dj":             true,
+}
+
 // Detect PNG image if "implicit" class is used
 var pngHeader = []byte{137, 80, 78, 71, 13, 10, 26, 10}
 
@@ -226,7 +232,7 @@ func readAtomHeader(r io.ReadSeeker) (name string, size uint32, err error) {
 
 // Generic atom.
 // Should have 3 sub atoms : mean, name and data.
-// We check that mean is "com.apple.iTunes" and we use the subname as
+// We check that mean is "com.apple.iTunes" or others and we use the subname as
 // the name, and move to the data atom.
 // Data atom could have multiple data values, each with a header.
 // If anything goes wrong, we jump at the end of the "----" atom.
@@ -268,9 +274,10 @@ func readCustomAtom(r io.ReadSeeker, size uint32) (_ string, data []string, _ er
 		return "", nil, err
 	}
 
-	if subNames["mean"] != "com.apple.iTunes" || subNames["name"] == "" || len(data) == 0 {
+	if !means[subNames["mean"]] || subNames["name"] == "" || len(data) == 0 {
 		return "----", nil, nil
 	}
+
 	return subNames["name"], data, nil
 }
 


### PR DESCRIPTION
This addresses an issue where no data is returned for MP4 files with atoms with mean `com.mixedinkey.mixedinkey` or `com.serato.dj`, from Mixed In Key and Serato DJ software.

Fixes #100