### PR TITLE
added genre codes 148 to 191 (winamp ext)

### DIFF
--- a/id3v2.go
+++ b/id3v2.go
@@ -44,14 +44,14 @@ var id3v2Genres = [...]string{
 	"Heavy Metal", "Black Metal", "Crossover", "Contemporary Christian",
 	"Christian Rock ", "Merengue", "Salsa", "Thrash Metal", "Anime", "JPop",
 	"Synthpop",
-	"Christmas", "Art rock", "Baroque", "Bhangra", "Big beat", "Breakbeat",
+	"Christmas", "Art Rock", "Baroque", "Bhangra", "Big Beat", "Breakbeat",
 	"Chillout", "Downtempo", "Dub", "EBM", "Eclectic", "Electro",
 	"Electroclash", "Emo", "Experimental", "Garage", "Global", "IDM",
 	"Illbient", "Industro-Goth", "Jam Band", "Krautrock", "Leftfield", "Lounge",
-	"Math rock", "New romantic", "Nu-breakz", "Post-punk", "Post-rock", "Psytrance",
-	"Shoegaze", "Space rock", "Trop rock", "World music", "Neoclassical", "Audiobook",
-	"Audio theatre", "Neue Deutsche Welle", "Podcast", "Indie-rock", "G-Funk", "Dubstep",
-	"Garage rock", "Psybient",
+	"Math Rock", "New Romantic", "Nu-Breakz", "Post-Punk", "Post-Rock", "Psytrance",
+	"Shoegaze", "Space Rock", "Trop Rock", "World Music", "Neoclassical", "Audiobook",
+	"Audio Theatre", "Neue Deutsche Welle", "Podcast", "Indie-Rock", "G-Funk", "Dubstep",
+	"Garage Rock", "Psybient",
 }
 
 // id3v2Header is a type which represents an ID3v2 tag header.

--- a/id3v2.go
+++ b/id3v2.go
@@ -50,7 +50,7 @@ var id3v2Genres = [...]string{
 	"Illbient", "Industro-Goth", "Jam Band", "Krautrock", "Leftfield", "Lounge",
 	"Math Rock", "New Romantic", "Nu-Breakz", "Post-Punk", "Post-Rock", "Psytrance",
 	"Shoegaze", "Space Rock", "Trop Rock", "World Music", "Neoclassical", "Audiobook",
-	"Audio Theatre", "Neue Deutsche Welle", "Podcast", "Indie-Rock", "G-Funk", "Dubstep",
+	"Audio Theatre", "Neue Deutsche Welle", "Podcast", "Indie Rock", "G-Funk", "Dubstep",
 	"Garage Rock", "Psybient",
 }
 

--- a/id3v2.go
+++ b/id3v2.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 )
 
+// Genre definitions 0-79 follow the ID3 tag specification of 1999.
+// More genres have been successively introduced in later Winamp versions.
+// https://en.wikipedia.org/wiki/List_of_ID3v1_genres#Extension_by_Winamp
 var id3v2Genres = [...]string{
 	"Blues", "Classic Rock", "Country", "Dance", "Disco", "Funk", "Grunge",
 	"Hip-Hop", "Jazz", "Metal", "New Age", "Oldies", "Other", "Pop", "R&B",
@@ -41,6 +44,14 @@ var id3v2Genres = [...]string{
 	"Heavy Metal", "Black Metal", "Crossover", "Contemporary Christian",
 	"Christian Rock ", "Merengue", "Salsa", "Thrash Metal", "Anime", "JPop",
 	"Synthpop",
+	"Christmas", "Art rock", "Baroque", "Bhangra", "Big beat", "Breakbeat",
+	"Chillout", "Downtempo", "Dub", "EBM", "Eclectic", "Electro",
+	"Electroclash", "Emo", "Experimental", "Garage", "Global", "IDM",
+	"Illbient", "Industro-Goth", "Jam Band", "Krautrock", "Leftfield", "Lounge",
+	"Math rock", "New romantic", "Nu-breakz", "Post-punk", "Post-rock", "Psytrance",
+	"Shoegaze", "Space rock", "Trop rock", "World music", "Neoclassical", "Audiobook",
+	"Audio theatre", "Neue Deutsche Welle", "Podcast", "Indie-rock", "G-Funk", "Dubstep",
+	"Garage rock", "Psybient",
 }
 
 // id3v2Header is a type which represents an ID3v2 tag header.

--- a/id3v2_test.go
+++ b/id3v2_test.go
@@ -142,6 +142,7 @@ func TestGenreExpension(t *testing.T) {
 		"(17)(93)":     "Rock Psychedelic Rock",
 		"(17)Test(93)": "Rock Test Psychedelic Rock",
 		"(175)":		"Post-Punk",
+		"(187)":		"Indie Rock",
 		"(191)":		"Psybient",
 	}
 	for g, r := range tests {

--- a/id3v2_test.go
+++ b/id3v2_test.go
@@ -141,6 +141,8 @@ func TestGenreExpension(t *testing.T) {
 		"Test (17)":    "Test Rock",
 		"(17)(93)":     "Rock Psychedelic Rock",
 		"(17)Test(93)": "Rock Test Psychedelic Rock",
+		"(175)":		"Post-punk",
+		"(191)":		"Psybient",
 	}
 	for g, r := range tests {
 		got := id3v2genre(g)

--- a/id3v2_test.go
+++ b/id3v2_test.go
@@ -141,7 +141,7 @@ func TestGenreExpension(t *testing.T) {
 		"Test (17)":    "Test Rock",
 		"(17)(93)":     "Rock Psychedelic Rock",
 		"(17)Test(93)": "Rock Test Psychedelic Rock",
-		"(175)":		"Post-punk",
+		"(175)":		"Post-Punk",
 		"(191)":		"Psybient",
 	}
 	for g, r := range tests {


### PR DESCRIPTION
Added support for genre codes in the [Winamp extension 148 to 191 range](https://en.wikipedia.org/wiki/List_of_ID3v1_genres#Extension_by_Winamp) e.g. return `"Post-Punk"` instead of `"(175)"`.
Addresses https://github.com/dhowden/tag/issues/102