### PR TITLE
Try to parse the year when 'year' tag could be a date

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20
+        go-version: "1.20"
         cache: true
 
     - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.20
         cache: true
 
     - name: Build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhowden/tag
 
-go 1.18
+go 1.20
 
 require github.com/dhowden/itl v0.0.0-20170329215456-9fbe21093131
 

--- a/id3v2metadata.go
+++ b/id3v2metadata.go
@@ -7,6 +7,7 @@ package tag
 import (
 	"strconv"
 	"strings"
+	"time"
 )
 
 type frameNames map[string][2]string
@@ -89,8 +90,19 @@ func (m metadataID3v2) Genre() string {
 }
 
 func (m metadataID3v2) Year() int {
-	year, _ := strconv.Atoi(m.getString(frames.Name("year", m.Format())))
-	return year
+	stringYear := m.getString(frames.Name("year", m.Format()))
+
+	year, _ := strconv.Atoi(stringYear)
+	if year != 0 {
+		return year
+	}
+
+	date, err := time.Parse(time.DateOnly, stringYear)
+	if err != nil {
+		return 0
+	}
+
+	return date.Year()
 }
 
 func parseXofN(s string) (x, n int) {

--- a/id3v2metadata.go
+++ b/id3v2metadata.go
@@ -92,8 +92,7 @@ func (m metadataID3v2) Genre() string {
 func (m metadataID3v2) Year() int {
 	stringYear := m.getString(frames.Name("year", m.Format()))
 
-	year, _ := strconv.Atoi(stringYear)
-	if year != 0 {
+	if year, err := strconv.Atoi(stringYear); err == nil {
 		return year
 	}
 


### PR DESCRIPTION
When the year/date tag is a date, it can't be parsed into a number, so the `Year()` method returns a zero value. This PR tries to fix this by checking if the `Atoi()` function returns 0. If it does, the string is parsed as a date, and the year is returned. If parsing fails, it still returns zero.