### PR TITLE
Recognise year field for ogg files when present

### DIFF
--- a/vorbis.go
+++ b/vorbis.go
@@ -210,19 +210,19 @@ func (m *metadataVorbis) Genre() string {
 }
 
 func (m *metadataVorbis) Year() int {
-	if len(m.c["year"]) != 0 {
-		year, err := strconv.Atoi(m.c["year"])
-		if err == nil {
-			return year
-		}
-	}
-
 	var dateFormat string
 
 	// The date need to follow the international standard https://en.wikipedia.org/wiki/ISO_8601
 	// and obviously the VorbisComment standard https://wiki.xiph.org/VorbisComment#Date_and_time
 	switch len(m.c["date"]) {
 	case 0:
+		// Fallback on year tag as some files use that.
+		if len(m.c["year"]) != 0 {
+			year, err := strconv.Atoi(m.c["year"])
+			if err == nil {
+				return year
+			}
+		}
 		return 0
 	case 4:
 		dateFormat = "2006"

--- a/vorbis.go
+++ b/vorbis.go
@@ -210,6 +210,13 @@ func (m *metadataVorbis) Genre() string {
 }
 
 func (m *metadataVorbis) Year() int {
+	if len(m.c["year"]) != 0 {
+		year, err := strconv.Atoi(m.c["year"])
+		if err == nil {
+			return year
+		}
+	}
+
 	var dateFormat string
 
 	// The date need to follow the international standard https://en.wikipedia.org/wiki/ISO_8601


### PR DESCRIPTION
Pretty much most of my music library is made up of ogg vorbis files with a Year field and no Date field. Some have both. This is cause some music players will recognize date and some will recognize year. So i don't know if it's part of any standard but i think it'd make sense to account for it here.