### PR TITLE
add duration for all formats

### DIFF
--- a/dsf.go
+++ b/dsf.go
@@ -7,12 +7,13 @@ package tag
 import (
 	"errors"
 	"io"
+	"time"
 )
 
-// ReadDSFTags reads DSF metadata from the io.ReadSeeker, returning the resulting
+// ReadDSFMeta reads DSF metadata from the io.ReadSeeker, returning the resulting
 // metadata in a Metadata implementation, or non-nil error if there was a problem.
 // samples: http://www.2l.no/hires/index.html
-func ReadDSFTags(r io.ReadSeeker) (Metadata, error) {
+func ReadDSFMeta(r io.ReadSeeker) (Metadata, error) {
 	dsd, err := readString(r, 4)
 	if err != nil {
 		return nil, err
@@ -31,6 +32,28 @@ func ReadDSFTags(r io.ReadSeeker) (Metadata, error) {
 		return nil, err
 	}
 
+	_, err = r.Seek(int64(28), io.SeekCurrent)
+	if err != nil {
+		return nil, err
+	}
+
+	sampleRate, err := readUint32LittleEndian(r)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = r.Seek(int64(4), io.SeekCurrent)
+	if err != nil {
+		return nil, err
+	}
+
+	sampleNum, err := readUint64LittleEndian(r)
+	if err != nil {
+		return nil, err
+	}
+
+	duration := time.Second * (time.Duration(sampleNum) / time.Duration(sampleRate))
+
 	_, err = r.Seek(int64(id3Pointer), io.SeekStart)
 	if err != nil {
 		return nil, err
@@ -41,69 +64,21 @@ func ReadDSFTags(r io.ReadSeeker) (Metadata, error) {
 		return nil, err
 	}
 
-	return metadataDSF{id3}, nil
+	return metadataDSF{
+		metadataID3v2: id3,
+		duration:      duration,
+	}, nil
 }
 
 type metadataDSF struct {
-	id3 Metadata
-}
-
-func (m metadataDSF) Format() Format {
-	return m.id3.Format()
+	*metadataID3v2
+	duration time.Duration
 }
 
 func (m metadataDSF) FileType() FileType {
 	return DSF
 }
 
-func (m metadataDSF) Title() string {
-	return m.id3.Title()
-}
-
-func (m metadataDSF) Album() string {
-	return m.id3.Album()
-}
-
-func (m metadataDSF) Artist() string {
-	return m.id3.Artist()
-}
-
-func (m metadataDSF) AlbumArtist() string {
-	return m.id3.AlbumArtist()
-}
-
-func (m metadataDSF) Composer() string {
-	return m.id3.Composer()
-}
-
-func (m metadataDSF) Year() int {
-	return m.id3.Year()
-}
-
-func (m metadataDSF) Genre() string {
-	return m.id3.Genre()
-}
-
-func (m metadataDSF) Track() (int, int) {
-	return m.id3.Track()
-}
-
-func (m metadataDSF) Disc() (int, int) {
-	return m.id3.Disc()
-}
-
-func (m metadataDSF) Picture() *Picture {
-	return m.id3.Picture()
-}
-
-func (m metadataDSF) Lyrics() string {
-	return m.id3.Lyrics()
-}
-
-func (m metadataDSF) Comment() string {
-	return m.id3.Comment()
-}
-
-func (m metadataDSF) Raw() map[string]interface{} {
-	return m.id3.Raw()
+func (m metadataDSF) Duration() time.Duration {
+	return m.duration
 }

--- a/flac.go
+++ b/flac.go
@@ -116,5 +116,5 @@ func (m *metadataFLAC) FileType() FileType {
 }
 
 func (m *metadataFLAC) Duration() time.Duration {
-	return time.Second
+	return m.duration
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhowden/tag
 
-go 1.20
+go 1.22
 
 require github.com/dhowden/itl v0.0.0-20170329215456-9fbe21093131
 

--- a/id3v1.go
+++ b/id3v1.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // id3v1Genres is a list of genres as given in the ID3v1 specification.
@@ -42,7 +43,7 @@ var ErrNotID3v1 = errors.New("invalid ID3v1 header")
 
 // ReadID3v1Tags reads ID3v1 tags from the io.ReadSeeker.  Returns ErrNotID3v1
 // if there are no ID3v1 tags, otherwise non-nil error if there was a problem.
-func ReadID3v1Tags(r io.ReadSeeker) (Metadata, error) {
+func ReadID3v1Tags(r io.ReadSeeker) (metadataID3v1, error) {
 	_, err := r.Seek(-128, io.SeekEnd)
 	if err != nil {
 		return nil, err
@@ -142,3 +143,6 @@ func (metadataID3v1) Disc() (int, int)      { return 0, 0 }
 func (m metadataID3v1) Picture() *Picture   { return nil }
 func (m metadataID3v1) Lyrics() string      { return "" }
 func (m metadataID3v1) Comment() string     { return m["comment"].(string) }
+func (m metadataID3v1) Duration() time.Duration {
+	return time.Second
+}

--- a/id3v1.go
+++ b/id3v1.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // id3v1Genres is a list of genres as given in the ID3v1 specification.
@@ -143,6 +142,3 @@ func (metadataID3v1) Disc() (int, int)      { return 0, 0 }
 func (m metadataID3v1) Picture() *Picture   { return nil }
 func (m metadataID3v1) Lyrics() string      { return "" }
 func (m metadataID3v1) Comment() string     { return m["comment"].(string) }
-func (m metadataID3v1) Duration() time.Duration {
-	return time.Second
-}

--- a/mp3.go
+++ b/mp3.go
@@ -1,0 +1,220 @@
+package tag
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"time"
+)
+
+type mpegVersion int
+
+const (
+	mpeg25 mpegVersion = iota
+	mpegReserved
+	mpeg2
+	mpeg1
+	mpegMax
+)
+
+type mpegLayer int
+
+const (
+	layerReserved mpegLayer = iota
+	layer3
+	layer2
+	layer1
+	layerMax
+)
+
+// Took from: https://github.com/tcolgate/mp3/blob/master/frames.go
+var (
+	bitrates = [mpegMax][layerMax][15]int{
+		{ // MPEG 2.5
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                       // LayerReserved
+			{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      // Layer3
+			{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      // Layer2
+			{0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}, // Layer1
+		},
+		{ // Reserved
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // LayerReserved
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Layer3
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Layer2
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Layer1
+		},
+		{ // MPEG 2
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                       // LayerReserved
+			{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      // Layer3
+			{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      // Layer2
+			{0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}, // Layer1
+		},
+		{ // MPEG 1
+			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                          // LayerReserved
+			{0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320},     // Layer3
+			{0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384},    // Layer2
+			{0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448}, // Layer1
+		},
+	}
+	sampleRates = [int(mpegMax)][3]int{
+		{11025, 12000, 8000},  //MPEG25
+		{0, 0, 0},             //MPEGReserved
+		{22050, 24000, 16000}, //MPEG2
+		{44100, 48000, 32000}, //MPEG1
+	}
+
+	samplesPerFrame = [mpegMax][layerMax]int{
+		{ // MPEG25
+			0,
+			576,
+			1152,
+			384,
+		},
+		{ // Reserved
+			0,
+			0,
+			0,
+			0,
+		},
+		{ // MPEG2
+			0,
+			576,
+			1152,
+			384,
+		},
+		{ // MPEG1
+			0,
+			1152,
+			1152,
+			384,
+		},
+	}
+	slotSize = [layerMax]int{
+		0, //	LayerReserved
+		1, //	Layer3
+		1, //	Layer2
+		4, //	Layer1
+	}
+)
+
+type metadataV2MP3 struct {
+	*metadataID3v2
+	duration time.Duration
+}
+
+type metadataV1MP3 struct {
+	*metadataID3v1
+	duration time.Duration
+}
+
+func getMP3Duration(header []byte, strippedSize int64) (time.Duration, error) {
+	version, err := cutBits(header, 11, 2)
+	if err != nil {
+		return 0, fmt.Errorf("reading mpeg version: %w", err)
+	}
+	layer, err := cutBits(header, 13, 2)
+	if err != nil {
+		return 0, fmt.Errorf("reading mpeg layer: %w", err)
+	}
+	protection, err := cutBits(header, 15, 1)
+	if err != nil {
+		return 0, fmt.Errorf("reading mpeg protection: %w", err)
+	}
+	bitrateIndex, err := cutBits(header, 16, 4)
+	if err != nil {
+		return 0, fmt.Errorf("reading mpeg bitrate index: %w", err)
+	}
+	samplerateIndex, err := cutBits(header, 20, 2)
+	if err != nil {
+		return 0, fmt.Errorf("reading mpeg samplerate index: %w", err)
+	}
+	padding, err := cutBits(header, 21, 1)
+	if err != nil {
+		return 0, fmt.Errorf("reading mpeg padding bit: %w", err)
+	}
+	frameSampleNum := samplesPerFrame[version][layer]
+	frameDuration := float64(frameSampleNum) / float64(sampleRates[version][samplerateIndex])
+	frameSize := math.Floor(((frameDuration * float64(bitrates[version][layer][bitrateIndex])) * 1000) / 8)
+	if padding == 1 {
+		frameSize += float64(slotSize[layer])
+	}
+	if protection == 1 {
+		frameSize += 2
+	}
+	// add the header length
+	frameSize += 4
+	duration := time.Second * time.Duration(math.Round((float64(strippedSize)/float64(frameSize))*frameDuration))
+
+	return duration, nil
+}
+
+func ReadV2MP3Meta(r io.ReadSeeker, size int64) (Metadata, error) {
+	tagMeta, err := ReadID3v2Tags(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading id3v2 tags: %w", err)
+	}
+
+	id3Size := tagMeta.header.Size + 10
+	if tagMeta.header.FooterPresent {
+		id3Size += 10
+	}
+	_, err = r.Seek(int64(id3Size), io.SeekStart)
+	if err != nil {
+		return nil, fmt.Errorf("seeking to skip id3v2: %w", err)
+
+	}
+
+	header := make([]byte, 4)
+	_, err = io.ReadFull(r, header)
+	if err != nil {
+		return nil, fmt.Errorf("reading first frame header: %w", err)
+	}
+
+	duration, err := getMP3Duration(header, size-int64(id3Size))
+	if err != nil {
+		return nil, fmt.Errorf("reading the mp3 duration: %w", err)
+	}
+
+	return &metadataV2MP3{
+		metadataID3v2: tagMeta,
+		duration:      duration,
+	}, nil
+
+}
+
+func ReadV1MP3Meta(r io.ReadSeeker, size int64) (Metadata, error) {
+	tagMeta, err := ReadID3v1Tags(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading id3v2 tags: %w", err)
+	}
+
+	_, err = r.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, fmt.Errorf("seeking to the start: %w", err)
+
+	}
+
+	header := make([]byte, 4)
+	_, err = io.ReadFull(r, header)
+	if err != nil {
+		return nil, fmt.Errorf("reading first frame header: %w", err)
+	}
+
+	duration, err := getMP3Duration(header, size-128)
+	if err != nil {
+		return nil, fmt.Errorf("reading the mp3 duration: %w", err)
+	}
+
+	return &metadataV1MP3{
+		metadataID3v1: &tagMeta,
+		duration:      duration,
+	}, nil
+
+}
+
+func (m *metadataV2MP3) Duration() time.Duration {
+	return m.duration
+}
+
+func (m *metadataV1MP3) Duration() time.Duration {
+	return m.duration
+}

--- a/mp4.go
+++ b/mp4.go
@@ -121,7 +121,7 @@ func (m *metadataMP4) readAtoms(r io.ReadSeeker) error {
 			}
 			m.duration = time.Second * (time.Duration(sampleNum) / time.Duration(sampleRate))
 
-			_, err = r.Seek(int64(size-8-12), io.SeekCurrent)
+			_, err = r.Seek(int64(size-8-12-8), io.SeekCurrent)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
As i am currently writing a file plugin for a my music server, i needed a library which reads metadata including the duration of a file as fast as possible.
All well established cgo binding based solutions (libvlc, taglib...) I've tested were at least 25% slower than this library.
So i decided to add duration support for this library.

This PR does change the public API of this library in several places, which i guess is not desired. As you have mentioned here https://github.com/dhowden/tag/pull/106#pullrequestreview-2198704244 you have a solution in mind for this problem. So i thought it might be smarter to wait for you to make a suggestion here after you saw my code and I'll adjust the PR accordingly. I think it wont be a lot of work as the code for the duration reading is already written now.

Technical notes:

- I deleted the reading of a ID3V1 tag if the filetype is not identified because you might assume that the unknown file is tagged with ID3V1 but i cant just assume it is audio file format XY for reading the duration.
- MP3 duration calculation is rather an estimation, all my testing mp3's were accurately calculated but it is not exact. One could add the XING header parsing and calculate it more accurately if the header is found but i am not really motivated to invest more time in to the MP3 standard.
- I renamed Read[Format]Tags to Read[Format]Meta because it now reads the duration too which might be seen as metadata but never as a tag.
- I've added structs for each format which contains a struct for the tags and a duration field, so the tags struct does not have to be changed.
