### PR TITLE
fix: Skip corrupted vorbis image tag

### DIFF
--- a/vorbis.go
+++ b/vorbis.go
@@ -62,7 +62,7 @@ func (m *metadataVorbis) readVorbisComment(r io.Reader) error {
 	if b64data, ok := m.c["metadata_block_picture"]; ok {
 		data, err := base64.StdEncoding.DecodeString(b64data)
 		if err != nil {
-			return err
+			return nil
 		}
 		m.readPictureBlock(bytes.NewReader(data))
 	}


### PR DESCRIPTION
When you pass a flac file or vorbis file with an image that is corrupted, the whole tag parsing failed.

This very tiny PR make if the base64 decoding of the corrupted file occurred, no error is return and we just assume there is no image available.